### PR TITLE
fix namespace bugs

### DIFF
--- a/SmartEye/SmartEye/Dcam.cpp
+++ b/SmartEye/SmartEye/Dcam.cpp
@@ -248,7 +248,7 @@ int DCam::setRealTemperature(char *buf)
 }
 
 //获取深度图像
-Mat DCam::getDepth()
+cv::Mat DCam::getDepth()
 {
 	cv::Mat dcam_imageinfor;            //深度图像
 	dcam_imageinfor = g_depthprocess.getDepth();

--- a/SmartEye/SmartEye/Dcam.h
+++ b/SmartEye/SmartEye/Dcam.h
@@ -19,7 +19,6 @@
 #define COLORMAP_MIN_DEPTH 0
 #define frametime  1000
 
-
 class DCam : public QThread
 {
 	Q_OBJECT
@@ -32,7 +31,7 @@ public:
 	void setRun(bool isRun);					//设置线程停止
 	void setNet(std::string ip, int port);		//设置相机IP，端口
 	void setPointcloudConvert(bool isConvert);	//设置点云显示
-	Mat  getDepth();							//获取深度图像
+	cv::Mat  getDepth();							//获取深度图像
 	void setCameraParameters(double fx, double fy, double cx, double cy, double k1, double k2, double p1, double p2, double k3);	//设置相机内参、畸变系数
 	int  setRealTemperature(char *buf);			//获取相机温度
 	bool getRunState();							//获取运行状态

--- a/SmartEye/SmartEye/Depthprocess.cpp
+++ b/SmartEye/SmartEye/Depthprocess.cpp
@@ -1,17 +1,17 @@
-#include"Depthprocess.h"
-
+ï»¿#include"Depthprocess.h"
+using namespace cv;
 Imagedepthprocess::Imagedepthprocess()
 {
 	_matimg_short.create(Img_height, Img_width, CV_16UC1);
 	_matimg_show.create(Img_height, Img_width, CV_16UC1);
-	 img_color.create(Img_height, Img_width, CV_8UC3);//¹¹ÔìRGBÍ¼Ïñ
+	 img_color.create(Img_height, Img_width, CV_8UC3);//æ„é€ RGBå›¾åƒ
 }
 Imagedepthprocess::~Imagedepthprocess()
 {
 
 }
-//Éî¶ÈÊı¾İ´¦Àí
-//·µ»Ø£ºCV_U8C3 matÀàĞÍ
+//æ·±åº¦æ•°æ®å¤„ç†
+//è¿”å›ï¼šCV_U8C3 matç±»å‹
 Mat Imagedepthprocess::depthProcess()
 {
 	uint16_t fameDepthArray2[MAXLINE];
@@ -19,13 +19,13 @@ Mat Imagedepthprocess::depthProcess()
 	{
 		raw_dep = ptr_buf_unsigned[j * 2 + 1] * 256 + ptr_buf_unsigned[2 * j];
 		//cout << raw_dep << " ";
-		realindex = bytecount / 2 - (j / Img_width + 1) * Img_width + j % Img_width;   //¾µÏñ
+		realindex = bytecount / 2 - (j / Img_width + 1) * Img_width + j % Img_width;   //é•œåƒ
 		realrow = Img_height - 1 - j / Img_width;
 		realcol = j % Img_width;
 		fameDepthArray2[realindex] = raw_dep;
 
 	}
-	//ÂË²¨
+	//æ»¤æ³¢
 	calibrate(fameDepthArray2);
 	uint16_t depth[240][320];
 	for (int i = 0; i < 240; i++)
@@ -35,7 +35,7 @@ Mat Imagedepthprocess::depthProcess()
 			depth[i][j] = fameDepthArray2[i * 320 + j];
 		}
 	}
-	//16bitÔ­Ê¼Êı¾İ
+	//16bitåŸå§‹æ•°æ®
 	for (int i = 0; i < 240; i++)
 	{
 		for (int j = 0; j < 320; j++)
@@ -46,7 +46,7 @@ Mat Imagedepthprocess::depthProcess()
 			}
 			else
 			{
-				//¼ÆËãÆ«ÒÆÁ¿
+				//è®¡ç®—åç§»é‡
 				if (depth[i][j] + offset < 0 && depth[i][j] + offset < 30000)
 					_matimg_short.at<ushort>(i, j) = 0;
 				else
@@ -58,14 +58,14 @@ Mat Imagedepthprocess::depthProcess()
 
 	}
 
-	//·­×ªÍ¼Ïñ
+	//ç¿»è½¬å›¾åƒ
 	if (isHorizontalFlip)
 	{
-		flip(_matimg_short, _matimg_short, 1);		//Ë®Æ½·­×ªÍ¼Ïñ
+		flip(_matimg_short, _matimg_short, 1);		//æ°´å¹³ç¿»è½¬å›¾åƒ
 	}
 	if (isVerticalFlip)
 	{
-		flip(_matimg_short, _matimg_short, 0);		//´¹Ö±·­×ªÍ¼Ïñ
+		flip(_matimg_short, _matimg_short, 0);		//å‚ç›´ç¿»è½¬å›¾åƒ
 	}
 
 	setColorImage();
@@ -73,25 +73,25 @@ Mat Imagedepthprocess::depthProcess()
 
 	return img_color.clone();
 }
-//»ñÈ¡Éî¶ÈÊı¾İ
-//·µ»Ø£ºMatÀàĞÍ
+//è·å–æ·±åº¦æ•°æ®
+//è¿”å›ï¼šMatç±»å‹
 Mat Imagedepthprocess::getDepth()
 {
 	return _matimg_short.clone();
 }
-//ÂË²¨
-//ÊäÈë£ºÍ¼ÏñĞÅÏ¢µÄÖ¸Õë
+//æ»¤æ³¢
+//è¾“å…¥ï¼šå›¾åƒä¿¡æ¯çš„æŒ‡é’ˆ
 void Imagedepthprocess::calibrate(ushort *img)
 {
-	//¾ùÖµÂË²¨
+	//å‡å€¼æ»¤æ³¢
 	imageAverageEightConnectivity(img);
-	//ÎÂ¶È½ÃÕı
+	//æ¸©åº¦çŸ«æ­£
 	//calculationCorrectDRNU(img);
-	//Éî¶È²¹³¥
+	//æ·±åº¦è¡¥å¿
 	calculationAddOffset(img);
 }
-//°Ë¾ùÖµÂË²¨
-//ÊäÈë£º Éî¶ÈÍ¼ÏñÖ¸Õë
+//å…«å‡å€¼æ»¤æ³¢
+//è¾“å…¥ï¼š æ·±åº¦å›¾åƒæŒ‡é’ˆ
 void  Imagedepthprocess::imageAverageEightConnectivity(ushort *depthdata)
 {
 	int pixelCounter;
@@ -112,7 +112,7 @@ void  Imagedepthprocess::imageAverageEightConnectivity(ushort *depthdata)
 			pixelCounter = 0;
 			pixdata = 0;
 
-			ushort temp = 0;				//¼ÇÂ¼ÎŞĞ§µãÀàĞÍ
+			ushort temp = 0;				//è®°å½•æ— æ•ˆç‚¹ç±»å‹
 
 			if (actualFrame[index] < 30000) {
 				pixelCounter++;
@@ -168,9 +168,9 @@ void  Imagedepthprocess::imageAverageEightConnectivity(ushort *depthdata)
 			}
 			else 
 				temp = actualFrame[index + 321];
-			//Èç¹ûÖÜÎ§ÓĞĞ§Êı¾İĞ¡ÓÚ6¼ÇÎªÎŞĞ§µã
+			//å¦‚æœå‘¨å›´æœ‰æ•ˆæ•°æ®å°äº6è®°ä¸ºæ— æ•ˆç‚¹
 			if (pixelCounter < 8) {
-				//ÎŞĞ§µã
+				//æ— æ•ˆç‚¹
 				*(depthdata + index) = temp;
 			}
 			else {
@@ -180,8 +180,8 @@ void  Imagedepthprocess::imageAverageEightConnectivity(ushort *depthdata)
 	}
 
 }
-//Éî¶È²¹³¥
-//ÊäÈë£ºÍ¼ÏñĞÅÏ¢Ö¸Õë
+//æ·±åº¦è¡¥å¿
+//è¾“å…¥ï¼šå›¾åƒä¿¡æ¯æŒ‡é’ˆ
 void  Imagedepthprocess::calculationAddOffset(ushort *img)
 {
 	int offset = 0;
@@ -199,9 +199,9 @@ void  Imagedepthprocess::calculationAddOffset(ushort *img)
 		}
 	}
 }
-//ÎÂ¶ÈĞ£Õı
-//ÊäÈë£ºÍ¼ÏñĞÅÏ¢Ö¸Õë
-//·µ»Ø£º0
+//æ¸©åº¦æ ¡æ­£
+//è¾“å…¥ï¼šå›¾åƒä¿¡æ¯æŒ‡é’ˆ
+//è¿”å›ï¼š0
 int Imagedepthprocess::calculationCorrectDRNU(ushort *img)
 {
 	//int		gTempCal_Temp = 0;
@@ -246,12 +246,12 @@ int Imagedepthprocess::calculationCorrectDRNU(ushort *img)
 	////printf(" pMem = %d, %d, %d\n", pMem[1300], pMem[1301], pMem[1302]);
 	return 0;
 }
-//ÉèÖÃÎ±²ÊÉ«²ÎÊı
+//è®¾ç½®ä¼ªå½©è‰²å‚æ•°
 void Imagedepthprocess::setColorImage()
 {
 	Mat depthzip = _matimg_short.clone();
 	double interdepth = 894.0 / (maxdepth - mindepth);
-	//¾àÀëÑ¹Ëõ³É0µ½255¿Õ¼ä
+	//è·ç¦»å‹ç¼©æˆ0åˆ°255ç©ºé—´
 	for (int i = 0; i < 240; i++)
 	{
 		for (int j = 0; j < 320; j++)
@@ -267,7 +267,7 @@ void Imagedepthprocess::setColorImage()
 			}
 			if (depthzip.at<ushort>(i, j) == LOW_AMPLITUDE)
 			{
-				//ÎŞĞ§µã
+				//æ— æ•ˆç‚¹
 				IMG_B(img_color, i, j) = 0;
 				IMG_G(img_color, i, j) = 0;
 				IMG_R(img_color, i, j) = 0;
@@ -275,7 +275,7 @@ void Imagedepthprocess::setColorImage()
 			}
 			else if (depthzip.at<ushort>(i, j) == OVER_EXPOSED)
 			{
-				//¹ıÆØµã
+				//è¿‡æ›ç‚¹
 				IMG_B(img_color, i, j) = 255;
 				IMG_G(img_color, i, j) = 14;
 				IMG_R(img_color, i, j) = 169;
@@ -283,14 +283,14 @@ void Imagedepthprocess::setColorImage()
 			}
 			else if (depthzip.at<ushort>(i, j) < mindepth)
 			{
-				//¹ıĞ¡µã
+				//è¿‡å°ç‚¹
 				IMG_B(img_color, i, j) = 0;
 				IMG_R(img_color, i, j) = 0;
 				IMG_G(img_color, i, j) = 0;
 				continue;
 			}
 
-			//Õı³£µãËõ·Å
+			//æ­£å¸¸ç‚¹ç¼©æ”¾
 			if (depthzip.at<ushort>(i, j) > maxdepth)
 			{
 				depthzip.at<ushort>(i, j) = maxdepth;
@@ -339,7 +339,7 @@ void Imagedepthprocess::setColorImage()
 	}
 	
 }
-//±£´æÉî¶ÈÍ¼
+//ä¿å­˜æ·±åº¦å›¾
 void Imagedepthprocess::saveImage()
 {
 	string fileassave = string(savestr.toLocal8Bit());

--- a/SmartEye/SmartEye/smarteye.cpp
+++ b/SmartEye/SmartEye/smarteye.cpp
@@ -1,6 +1,6 @@
 #include "smarteye.h"
 
-
+using namespace cv;
 
 SmartEye::SmartEye(QWidget *parent)
 	: QMainWindow(parent)

--- a/SmartEye/SmartEye/smarteye.h
+++ b/SmartEye/SmartEye/smarteye.h
@@ -1,4 +1,4 @@
-#ifndef SMARTEYE_H
+ï»¿#ifndef SMARTEYE_H
 #define SMARTEYE_H
 
 #include <vtkAutoInit.h> 
@@ -34,7 +34,7 @@ VTK_MODULE_INIT(vtkInteractionStyle);
 #include <pcl/point_cloud.h>
 
 using namespace std;
-using namespace cv;
+//using namespace cv;
 
 
 
@@ -48,48 +48,48 @@ public:
 	QLabel *label;
 	DCam *g_dcam;
 	
-	//void depthprocess(); //Éî¶ÈÍ¼Ïñ´¦Àí
-	void showImage(Mat imshowsrc);//ÏÔÊ¾Í¼Ïñ
-	void showFrame(float frame); //ÏÔÊ¾Ö¡ÂÊ
+	//void depthprocess(); //æ·±åº¦å›¾åƒå¤„ç†
+	void showImage(cv::Mat imshowsrc);//æ˜¾ç¤ºå›¾åƒ
+	void showFrame(float frame); //æ˜¾ç¤ºå¸§ç‡
 
 protected:
-	bool eventFilter(QObject *, QEvent *);	//¹ıÂËÍ¼Æ¬labelµã»÷ÊÂ¼ş£¬»ñÈ¡×ø±êÎ»ÖÃ
+	bool eventFilter(QObject *, QEvent *);	//è¿‡æ»¤å›¾ç‰‡labelç‚¹å‡»äº‹ä»¶ï¼Œè·å–åæ ‡ä½ç½®
 
 private:
 	Ui::SmartEyeClass ui;
-	int connectState = 0;					//socketÁ¬½Ó×´Ì¬£¬ÓÃÓÚ¸üĞÂÁ¬½Ó°´Å¥ui 0ÎŞÁ¬½Ó 1Á¬½Ó
-	int savestate = 0;						//±£´æ×´Ì¬ 0Î´±£´æ 1ÕıÔÚ±£´æ
-	int savepcdstate = 0;					//±£´æpcdÎÄ¼ş 0²»±£´æ 1ÕıÔÚ±£´æ
-	bool isPCLShow = false;					//ÊÇ·ñµãÔÆ×ª»»±êÖ¾
-	boost::shared_ptr<pcl::visualization::PCLVisualizer> viewer;	//PCL¿ÉÊÓ»¯´°¿Ú
-	PointCloudT::Ptr cloud;					//µãÔÆÖ¸Õë     
-	PointCloudT::Ptr cloud_clicked;			//µã»÷ÊÂ¼ş´¦ÀíµãÔÆ
-	int pointSize=1;						//µãÔÆÏÔÊ¾´óĞ¡
+	int connectState = 0;					//socketè¿æ¥çŠ¶æ€ï¼Œç”¨äºæ›´æ–°è¿æ¥æŒ‰é’®ui 0æ— è¿æ¥ 1è¿æ¥
+	int savestate = 0;						//ä¿å­˜çŠ¶æ€ 0æœªä¿å­˜ 1æ­£åœ¨ä¿å­˜
+	int savepcdstate = 0;					//ä¿å­˜pcdæ–‡ä»¶ 0ä¸ä¿å­˜ 1æ­£åœ¨ä¿å­˜
+	bool isPCLShow = false;					//æ˜¯å¦ç‚¹äº‘è½¬æ¢æ ‡å¿—
+	boost::shared_ptr<pcl::visualization::PCLVisualizer> viewer;	//PCLå¯è§†åŒ–çª—å£
+	PointCloudT::Ptr cloud;					//ç‚¹äº‘æŒ‡é’ˆ     
+	PointCloudT::Ptr cloud_clicked;			//ç‚¹å‡»äº‹ä»¶å¤„ç†ç‚¹äº‘
+	int pointSize=1;						//ç‚¹äº‘æ˜¾ç¤ºå¤§å°
 
 	
 
-	void showPointCloud();				//µãÔÆÏÔÊ¾¸üĞÂ
-	void getCameraParameterFromFile();	//´Óconfig.ini»ñÈ¡²ÎÊı
-	void pp_callback(const pcl::visualization::PointPickingEvent& event, void *args);	//µãÔÆµã»÷»Øµ÷º¯Êı
+	void showPointCloud();				//ç‚¹äº‘æ˜¾ç¤ºæ›´æ–°
+	void getCameraParameterFromFile();	//ä»config.iniè·å–å‚æ•°
+	void pp_callback(const pcl::visualization::PointPickingEvent& event, void *args);	//ç‚¹äº‘ç‚¹å‡»å›è°ƒå‡½æ•°
 	
 
 private slots:
-	void imageUpdateSlot(cv::Mat img,float frame,int isImg);	//¸üĞÂÍ¼ÏñĞÅºÅ
-	void pointCloudUpdateSlot(PointCloudT::Ptr c);	//¸üĞÂµãÔÆĞÅÏ¢
-	void connectButtonPressedSlot();	//Á¬½Ó°´Å¥µã»÷²Û
-	void pclButtonPressedSlot();		//µãÔÆ×ª»»¹¦ÄÜ 
-	void setIntegrationTime3DSlot();	//ÉèÖÃ3D»ı·ÖÊ±¼ä
-	void setMinAmpSlot();                //ÉèÖÃ×îĞ¡ĞÅºÅÇ¿¶ÈÖ¸Áî
-	void setMappingDistanceSlot();		//ÉèÖÃÓ³Éä¾àÀë
-	void saveFileSlot();				//±£´æÊı¾İ
-	void savePCDSlot();					//±£´æPCDÎÄ¼ş
-	void pointSizeSliderReleaseSlot();	//µãÔÆ´óĞ¡ÉèÖÃ
-	void colormapPointCheckBoxSlot(int value);	//Î±²ÊÉ«µãÔÆ²Û
-	void pointFilterSlot();				//µãÔÆ¹ıÂË²Û£¨ÎªÁËÆ½ºâÏÔÊ¾ºÍµãÔÆÃÜ¶È£¬ÉèÖÃµãµÄ¹ıÂË³Ì¶È£©
-	void horizontalFlipSlot();			//Ë®Æ½·­×ª¹´Ñ¡¿ò
-	void verticalFlipSlot();			//´¹Ö±·­×ª¹´Ñ¡¿ò
-	void versionUpdateSlot(ushort);		//°æ±¾¸üĞÂÏÔÊ¾²Û
-	void setOffsetSlot();				//ÉèÖÃÆ«ÒÆÁ¿ÏàÓ¦²Û
+	void imageUpdateSlot(cv::Mat img,float frame,int isImg);	//æ›´æ–°å›¾åƒä¿¡å·
+	void pointCloudUpdateSlot(PointCloudT::Ptr c);	//æ›´æ–°ç‚¹äº‘ä¿¡æ¯
+	void connectButtonPressedSlot();	//è¿æ¥æŒ‰é’®ç‚¹å‡»æ§½
+	void pclButtonPressedSlot();		//ç‚¹äº‘è½¬æ¢åŠŸèƒ½ 
+	void setIntegrationTime3DSlot();	//è®¾ç½®3Dç§¯åˆ†æ—¶é—´
+	void setMinAmpSlot();                //è®¾ç½®æœ€å°ä¿¡å·å¼ºåº¦æŒ‡ä»¤
+	void setMappingDistanceSlot();		//è®¾ç½®æ˜ å°„è·ç¦»
+	void saveFileSlot();				//ä¿å­˜æ•°æ®
+	void savePCDSlot();					//ä¿å­˜PCDæ–‡ä»¶
+	void pointSizeSliderReleaseSlot();	//ç‚¹äº‘å¤§å°è®¾ç½®
+	void colormapPointCheckBoxSlot(int value);	//ä¼ªå½©è‰²ç‚¹äº‘æ§½
+	void pointFilterSlot();				//ç‚¹äº‘è¿‡æ»¤æ§½ï¼ˆä¸ºäº†å¹³è¡¡æ˜¾ç¤ºå’Œç‚¹äº‘å¯†åº¦ï¼Œè®¾ç½®ç‚¹çš„è¿‡æ»¤ç¨‹åº¦ï¼‰
+	void horizontalFlipSlot();			//æ°´å¹³ç¿»è½¬å‹¾é€‰æ¡†
+	void verticalFlipSlot();			//å‚ç›´ç¿»è½¬å‹¾é€‰æ¡†
+	void versionUpdateSlot(ushort);		//ç‰ˆæœ¬æ›´æ–°æ˜¾ç¤ºæ§½
+	void setOffsetSlot();				//è®¾ç½®åç§»é‡ç›¸åº”æ§½
 
 };
 


### PR DESCRIPTION
Hey, guys! It's seems there is some building errors (vs2017 + opencv3.4.7) with " using namespace cv " in a header. This pulled cv::ACCESS_MASK into global scope where it clashed with the already global Windows-defined ACCESS_MASK. 
so I removed the "using namespace cv" to the .cpp files, problems solved.